### PR TITLE
Docs: update references about postpack

### DIFF
--- a/00-packages.R
+++ b/00-packages.R
@@ -3,6 +3,6 @@ library(kableExtra)     # for building nice tables in Rmarkdown; install.package
 library(reshape2)       # for reformatting data (e.g., long to wide); install.packages("reshape2")
 library(abind)          # for binding together array objects; install.packages("abind")
 library(jagsUI)         # for calling JAGS from R; install.packages("jagsUI")
-library(postpack)       # for processing posterior samples; remotes::install.packages("bstaton1/postpack")
+library(postpack)       # for processing posterior samples; install.packages("postpack")
 library(scales)         # for transparent colors in plots; install.packages("scales")
 library(mvtnorm)        # for sampling multivariate normal random variables; install.packages("mvtnorm")

--- a/03-post-process/output-plots.Rmd
+++ b/03-post-process/output-plots.Rmd
@@ -41,7 +41,7 @@ jags_data = model_info$jags_data
 observable = (jags_data$kmax+1):jags_data$ny
 ```
 
-The code used to render this output relies heavily on Staton's 'postpack' package (currently under CRAN review). Take a look at [this vignette](https://bstaton1.github.io/postpack/articles/feature-overview.html) for a primer on how to use it.
+The code used to render this output relies heavily on Staton's 'postpack' package (now available on CRAN). Take a look at [this vignette](https://bstaton1.github.io/postpack/articles/feature-overview.html) for a primer on how to use it.
 
 # MCMC Information {.tabset .tabset-pills}
 

--- a/99-admin/README.md
+++ b/99-admin/README.md
@@ -93,7 +93,7 @@ We are using the [**Feature Branch Workflow**](https://www.atlassian.com/git/tut
   
   * If you include a new package into this file, include a brief statement about what it is used for and how to obtain it, e.g.,
     ```R
-    library(postpack) # summarizing posterior samples; remotes::install_github("bstaton1/postpack")
+    library(postpack) # summarizing posterior samples; install.packages("postpack")
     library(jagsUI)   # calling JAGS from R; install.packages("jagsUI")
     ```
   * To the extent practicable, we should strive to minimize dependencies


### PR DESCRIPTION
Staton's 'postpack' package has passed CRAN review and is currently hosted on their servers. This PR updates all documentation that previously stated it was hosted only on GitHub.

**COLLABORATORS**

If you have an old version of 'postpack', you are strongly recommended to update it using:

```R
install.packages("postpack")
```

And check you have the correct version:

```R
packageVersion("postpack")
````

You should see you have version 0.5.2.