### PR TITLE
Discard recaptured adults from weir compositions

### DIFF
--- a/00-data/prep-bio-data.R
+++ b/00-data/prep-bio-data.R
@@ -116,6 +116,9 @@ tmp = tmp[tmp$sex != "Unk",]
 # discard records with unknown origin
 tmp = tmp[tmp$origin != "Unk",]
 
+# discard records for recaptured fish
+tmp = tmp[-which(tmp$recapture),]
+
 # rename trap_year to year
 colnames(tmp)[colnames(tmp) == "trap_year"] = "year"
 
@@ -171,6 +174,9 @@ tmp = tmp[tmp$origin != "Unk",]
 
 # rename trap_year to year
 colnames(tmp)[colnames(tmp) == "trap_year"] = "year"
+
+# discard records for recaptured fish
+tmp = tmp[-which(tmp$recapture),]
 
 # keep only fish that were removed
 tmp = tmp[tmp$disposition == "removed",]


### PR DESCRIPTION
See #37 for details. I removed any fish with `recapture == TRUE` in both counting up fish arriving to the weir (for `bio_dat` columns `weir_ORIGIN_SEX_AGE`) and in fish removed at weir (for `bio_dat` columns `rm_ORIGIN_SEX_AGE`).

Merging this PR will close #37 