### PR TITLE
Add a pre-spawn carcass count threshold

### DIFF
--- a/00-data/prep-bio-data.R
+++ b/00-data/prep-bio-data.R
@@ -209,7 +209,7 @@ adult_rm_composition = tmp; rm(tmp)
 # years with fewer carcasses sampled than this will be assigned
 # NA values for numbers of carcasses sampled and found with spawn status
 # intended to remove the effects of weakly informative data
-status_count_threshold = 10
+status_count_threshold = 0
 
 # read the data
 tmp = read.csv(file.path(data_dir, "02a-adult-indiv-carcass.csv"), stringsAsFactors = F)


### PR DESCRIPTION
See #38 for details.

Implementing a threshold of 10 fish didn't have the expected effect for UGR. See attachment below figure for details. The "with censoring", and "no censoring" posterior time series look pretty similar, indicating that the swing in 1995 of near zero pre-spawn survival is coming from somewhere else in the model/data than in the pre-spawn data. Perhaps this is a year with a very low recruitment (of parr) residual, and the model tries to explain this with a low number of effective spawners?

![compare-UGR-with-without-censor](https://user-images.githubusercontent.com/42722538/95231783-7304bf80-07b8-11eb-9647-222e692a63f9.png)

Merging this change will close #38.