### PR TITLE
Add model comparison functions

### DIFF
--- a/01-functions/plot-fns.R
+++ b/01-functions/plot-fns.R
@@ -103,3 +103,206 @@ plot_tseries = function(est, obs = NULL, main = NULL, xaxis = T, yaxis_side = 2,
   } 
   if (!is.null(yaxis_side)) axis(side = yaxis_side)
 }
+
+##### FUNCTIONS FOR COMPARING POSTERIORS AMONG 2 OR MORE MODELS #####
+
+## EXAMPLE USAGE OF THESE FUNCTIONS ##
+# store two or more mcmc.lists as list elements, call it post_list
+
+# legend = list(a = "topleft", b = NULL, c = NULL, d = NULL)
+# main = c("CAT", "LOS", "MIN", "UGR")
+# 
+# # COMPARE ALPHA ESTIMATES FOR EACH POPULATION ACROSS MODELS
+# compare_param(post_list, "^alpha[pop]", pop = 1:4, main = "Max Egg-to-Parr Survival", legend = "topleft")
+# 
+# # COMPARE ADULT RETURNS TO EACH POPULATION ACROSS MODELS, WITH DATA+OBS VARIABILITY SHOWN
+# par(mfrow = c(2,2), oma = c(2,2,0,0))
+# sapply(1:4, function(j) {
+#   compare_tseries(post_list, "^Ra_tot[.+,pop]", yrs = 1991:2019, 
+#                   obs = get_obs_ests_log_normal(log(jags_data$Ra_obs[as.character(1991:2019),j]), jags_data$sig_Ra_obs[as.character(1991:2019),j]),
+#                   pop = j, origin = 1, main = main[j], legend = legend[[j]], y_scale = 1000)
+# })
+# mtext(side = 1, outer = TRUE, line = 0.5, "Return Year")
+# mtext(side = 2, outer = TRUE, line = 0.5, "Total Adults (000s)")
+# 
+# # COMPARE 1ST YEAR NOR OCEAN SURVIVAL ACROSS MODELS, NO DATA TO SHOW
+# par(mfrow = c(2,2), oma = c(2,2,0,0))
+# sapply(1:4, function(j) {
+#   compare_tseries(post_list, "^phi_O0_O1[.+,origin,pop]", yrs = 1991:2019, pop = j, origin = 1, main = main[j], legend = legend[[j]])
+# })
+# mtext(side = 1, outer = TRUE, line = 0.5, "Brood Year")
+# mtext(side = 2, outer = TRUE, line = 0.5, "Yr1 Ocean Survival (NOR)")
+# 
+# # COMPARE THE BH RELATIONSHIP FOR EACH POPULATION ACROSS MODELS
+# par(mfrow = c(2,2), oma = c(2,2,0,0))
+# sapply(1:4, function(j) {
+#   compare_BH(post_list, pop = j, main = main[j], legend = legend[[j]])
+# })
+# mtext(side = 1, outer = TRUE, line = 0.5, "Total Egg Production (000 000s)")
+# mtext(side = 2, outer = TRUE, line = 0.5, "Total Parr Recruitment (000s)")
+
+# function to create a plot comparing posterior summmaries of the same quantity among models
+compare_param = function(post_list, param, ylab = "", main = "", legend = "topleft", y_scale = 1, pt_est = "mean", cols = NULL, ylim = NULL, ...) {
+  
+  # get identifier for each element that will be summarized
+  param_ID = dim_IDs(param, ...)
+  
+  # get posterior summaries from all models
+  ests = lapply(post_list, function(post) post_summ(post, sub_index(param, ...), probs = c(0.025, 0.25, 0.5, 0.75, 0.975)))
+  
+  # convert summaries into an array format rather than a list format (models are third dimension)
+  ests = do.call(abind, append(ests, list(along = 3)))
+  dimnames(ests)[[2]] = param_ID
+  
+  # calculate the y-axis limits if not supplied
+  if (is.null(ylim)) {
+    y_range = range(ests[stringr::str_detect(dimnames(ests)[[1]], "%"),,])
+    y_diff = diff(y_range)
+    ylim = y_range + c(-1,1) * 0.05 * y_diff
+  }
+  
+  # define colors if not supplied
+  if (is.null(cols)) {
+    all_cols = c("salmon", "skyblue2", "orange", "forestgreen")
+    cols = all_cols[1:length(post_list)]
+  } 
+  
+  # graphics parameters
+  par(lend = "square", mgp = c(2,0.35,0), tcl = -0.15, mar = c(2,2,2,1))
+  
+  # empty plot
+  mp = barplot(t(ests[pt_est,,]), beside = TRUE, col = "white", border = NA, ylim = ylim, yaxt = "n", ylab = ylab, main = main)
+  usr = par("usr")
+  segments(usr[1], usr[3], usr[2], usr[3], xpd = TRUE)
+  segments(usr[1], usr[3], usr[1], usr[4], xpd = TRUE)
+  
+  # draw uncertainty intervals
+  segments(mp, t(ests["2.5%",,]), mp, t(ests["97.5%",,]), col = cols)
+  segments(mp, t(ests["25%",,]), mp, t(ests["75%",,]), lwd = 6, col = cols)
+  
+  # draw point estimates
+  points(x = mp, y = t(ests[pt_est,,]), cex = 1.5, pch = 3, col = cols)
+  
+  # draw axes
+  at_y = axisTicks(usr[3:4], log = FALSE)
+  axis(side = 1, at = colSums(mp)/nrow(mp), labels = FALSE)
+  axis(side = 2, at = at_y, labels = at_y/y_scale, las = 2)
+  
+  if (!is.null(legend)) {
+    legend(legend, legend = names(post_list), pch = 15, col = cols, pt.cex = 2, bty = "n")
+  }
+}
+
+# function to create a plot comparing a posterior summaries of the same time series among models
+compare_tseries = function(post_list, param, yrs, obs = NULL, ylab = "", xlab = "", main = "", legend = "topleft", y_scale = 1, pt_est = "mean", cols = NULL, ylim = NULL,  ...) {
+  
+  # get posterior summaries from all models
+  ests = lapply(post_list, function(post) post_summ(post, sub_index(param, ...), probs = c(0.025, 0.25, 0.5, 0.75, 0.975)))
+  
+  # convert summaries into an array format rather than a list format (models are third dimension)
+  ests = do.call(abind, append(ests, list(along = 3)))
+  
+  # calculate the y-axis limits
+  if (is.null(ylim)) {
+    y_range = range(ests[stringr::str_detect(dimnames(ests)[[1]], "%"),,], obs)
+    y_diff = diff(y_range)
+    ylim = y_range + c(-1,1) * 0.05 * y_diff
+    ylim[1] = 0
+  }
+  
+  # define colors if not supplied
+  if (is.null(cols)) {
+    all_cols = c("salmon", "skyblue2", "orange", "forestgreen")
+    cols = all_cols[1:length(post_list)]
+  } 
+  tcols = scales::alpha(cols, 0.3)
+  
+  # graphics parameters
+  par(mar = c(2,2,2,1), lend = "square", mgp = c(2,0.35,0), tcl = -0.15)
+  
+  plot(1,1, type = "n", xlim = range(yrs), ylim = ylim, main = main, ylab = ylab, xaxt = "n", yaxt = "n", xlab = xlab)
+  usr = par("usr")
+  junk = sapply(1:dim(ests)[3], function(i) {
+    polygon(x = c(yrs, rev(yrs)), y = c(ests["2.5%",,i], rev(ests["97.5%",,i])), col = tcols[i], border = NA)
+    lines(ests[pt_est,,i] ~ yrs, col = cols[i], lwd = 2)
+    lines(ests["2.5%",,i] ~ yrs, col = cols[i], lty = 2)
+    lines(ests["97.5%",,i] ~ yrs, col = cols[i], lty = 2)
+  })
+  
+  # draw data if provided
+  if (!is.null(obs)) {
+    segments(yrs, obs[,"lwr95"], yrs, obs[,"upr95"], col = alpha("grey25", 0.25))
+    points(obs[,"mean"] ~ yrs, pch = 21, col = alpha("grey25", 0.5), bg = alpha("grey25", 0.25), cex = 1.2)
+  } 
+  
+  # draw axes
+  at_x = axisTicks(usr[1:2], log = FALSE)
+  at_y = axisTicks(usr[3:4], log = FALSE)
+  axis(side = 1, at = at_x, labels = at_x)
+  axis(side = 2, at = at_y, labels = at_y/y_scale, las = 2)
+  
+  if (!is.null(legend)) {
+    if (is.null(obs)) {
+      legend(legend, legend = names(post_list), pch = 15, col = cols, pt.cex = 2, bty = "n")
+    } else {
+      legend(legend, legend = c(names(post_list), "Data"), pch = 15, col = c(cols, "grey"), pt.cex = 2, bty = "n")
+    }
+  }
+}
+
+# function to compare BH relationships for one population across multiple models
+compare_BH = function(post_list, pop, main = "", legend = "topleft", cols = NULL) {
+  
+  # function to get a sequence of egg abundances to predict at
+  # calculates a 30 element vector counting up from zero to the maximum 97.5% quantile of eggs by a given population across models
+  get_pred_eggs = function(j) {
+    max_eggs = max(unlist(lapply(post_list, function(post) max(post_summ(post, sub_index("f_tot[.+,pop]", pop = j))["97.5%",]))))
+    pred_eggs = seq(0, max_eggs, length = 30)
+    return(pred_eggs)
+  }
+  
+  # function to posterior summaries of predicted parr at each egg abundance
+  get_pred_parr = function(post, j) {
+    alpha_post = post_subset(post, sub_index("alpha[pop]", pop = j), TRUE)
+    beta_post = post_subset(post, sub_index("beta[pop]", pop = j), TRUE)
+    pred_eggs = get_pred_eggs(j)
+    pred_parr = sapply(1:nrow(alpha_post), function(i) BH(pred_eggs, alpha_post[i], beta_post[i]))
+    apply(pred_parr, 1, function(x) c(mean = mean(x), quantile(x, c(0.025, 0.975))))
+  }
+  
+  # get the sequence of egg abundances to predict parr abundances at
+  pred_eggs = get_pred_eggs(pop)
+  
+  # get posterior of predicted parr abundances
+  pred_parr = lapply(post_list, get_pred_parr, j = pop)
+  
+  # define colors if not supplied
+  if (is.null(cols)) {
+    all_cols = c("salmon", "skyblue2", "orange", "forestgreen")
+    cols = all_cols[1:length(post_list)]
+  } 
+  tcols = scales::alpha(cols, 0.3)
+  
+  # graphics parameters
+  par(mar = c(2,2,2,1), lend = "square", mgp = c(2,0.35,0), tcl = -0.15)
+  
+  plot(1,1, type = "n", xlim = range(pred_eggs), ylim = c(0, max(pred_parr[[1]], pred_parr[[2]])),
+       main = main, xaxt = "n", yaxt = "n", xlab = "", ylab = "")
+  usr = par("usr")
+  junk = sapply(1:length(post_list), function(i) {
+    polygon(x = c(pred_eggs, rev(pred_eggs)), y = c(pred_parr[[i]]["2.5%",], rev(pred_parr[[i]]["97.5%",])), col = tcols[i], border = NA)
+    lines(pred_parr[[i]]["mean",] ~ pred_eggs, col = cols[i], lwd = 2)
+    lines(pred_parr[[i]]["2.5%",] ~ pred_eggs, col = cols[i], lty = 2)
+    lines(pred_parr[[i]]["97.5%",] ~ pred_eggs, col = cols[i], lty = 2)
+  })
+  
+  # draw axes
+  at_x = axisTicks(usr[1:2], log = FALSE)
+  at_y = axisTicks(usr[3:4], log = FALSE)
+  axis(side = 1, at = at_x, labels = at_x/1e6)
+  axis(side = 2, at = at_y, labels = at_y/1000, las = 2)
+  
+  if (!is.null(legend)) {
+    legend(legend, legend = names(post_list), pch = 15, col = cols, pt.cex = 2, bty = "n")
+  }
+}

--- a/01-functions/util-fns.R
+++ b/01-functions/util-fns.R
@@ -159,6 +159,37 @@ sub_index = function(x, year = NULL, LH_type = NULL, age = NULL, origin = NULL, 
   newx
 }
 
+##### OBTAIN PARAMETER DIMENSION ID #####
+# E.G., dim_IDs("alpha[pop]", pop = 1) gives "CAT"
+# used for labeling in figures
+
+dim_IDs = function(param, ...) {
+  
+  # function to convert sub_index() output into named dimensions
+  dim_names = function(LH_type = NULL, age = NULL, origin = NULL, pop = NULL) {
+    
+    # empty list
+    out = list()
+    
+    # combine the dimention names for each type supplied
+    if (!is.null(LH_type)) out = append(out, list(LH_type = c("fall", "spring")[LH_type]))
+    if (!is.null(age)) out = append(out, list(age = c("age3", "age4", "age5")[age]))
+    if (!is.null(origin)) out = append(out, list(origin = c("NOR", "HOR")[origin]))
+    if (!is.null(pop)) out = append(out, list(pop = c("CAT", "LOS", "MIN", "UGR")[pop]))
+    
+    return(out)
+  }
+  
+  named_param = do.call(sub_index, append(list(x = param), dim_names(...)))
+  named_param = stringr::str_remove(named_param, "year,")
+  named_param = stringr::str_extract(named_param, "\\[.+\\]")
+  named_param = stringr::str_remove(named_param, "age[:digit:],")
+  named_param = stringr::str_remove(named_param, "\\[")
+  named_param = stringr::str_remove(named_param, "\\]")
+  return(named_param)
+}
+
+
 ##### COMBINE A LIST OF DATA FRAMES #####
 # list: a list with data frames to be rbind-ed stored as elements
 


### PR DESCRIPTION
This PR addresses #118 and adds several functions for comparing output from multiple models. To use the functions, the posterior samples (`post`) from each model (currently stored as `mcmc.list`s) should be made elements of a larger list (`post_list`), and these functions will extract the same quantity (`param`, subjected to `sub_index(param, ...)` from each model and plot them side by side.

Three main functions for this were added:

* `compare_param()`
* `compare_tseries()`
* `compare_BH()`

See `01-functions/plot-fns.R` for example usage.